### PR TITLE
ci: remove hard-coded package url

### DIFF
--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -54,15 +54,18 @@ jobs:
         env:
           TAG: ${{ github.ref_name }}
         run: |
+          PROJECT="${{ fromJson(steps.metadata.outputs.METADATA_JSON).packages[0].name }}"
           PACKAGE="${{ fromJson(steps.metadata.outputs.METADATA_JSON).packages[0].metadata.component.package }}"
           VERSION=`echo "${TAG}" | sed -E 's/v(.*)/\1/'`
           CHECKSUM=`head -1 checksum.txt | sed -E 's/^(.*) .*/\1/'`
+          echo "PROJECT=$PROJECT" >> "$GITHUB_OUTPUT"
           echo "PACKAGE=$PACKAGE" >> "$GITHUB_OUTPUT"
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "CHECKSUM=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: Create README.txt
         env:
+          PROJECT: ${{ steps.extract.outputs.PROJECT }}
           PACKAGE: ${{ steps.extract.outputs.PACKAGE }}
           VERSION: ${{ steps.extract.outputs.VERSION }}
           CHECKSUM: ${{ steps.extract.outputs.CHECKSUM }}
@@ -79,7 +82,7 @@ jobs:
           create server example_server
             foreign data wrapper wasm_wrapper
             options (
-              fdw_package_url 'https://github.com/supabase-community/wasm-fdw-example/releases/download/v${VERSION}/wasm_fdw_example.wasm',
+              fdw_package_url 'https://github.com/${GITHUB_REPOSITORY}/releases/download/v${VERSION}/${PROJECT}.wasm',
               fdw_package_name '${PACKAGE}',
               fdw_package_version '${VERSION}',
               fdw_package_checksum '${CHECKSUM}',


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to use variables to make the released package url dynamic, so it will match the user's cloned repo.

## What is the current behavior?

Currently the package url in release README is fixed to this template repo `supabase-community/wasm-fdw-example`, which is incorrect in user's cloned repo.

## What is the new behavior?

Use variables to substitute the package url, so it can match user's cloned repo.

## Additional context

N/A
