### PR TITLE
fix: supabase db container name in local-dev.sh

### DIFF
--- a/local-dev.sh
+++ b/local-dev.sh
@@ -7,4 +7,5 @@ cargo component build --release --target wasm32-unknown-unknown
 
 # set wasm file permission and copy it into supabase db container
 chmod +r target/wasm32-unknown-unknown/release/*.wasm
-docker cp target/wasm32-unknown-unknown/release/*.wasm supabase_db_supabase:/
+db_container=`docker ps --format "{{.Names}}" | grep supabase_db_`
+docker cp target/wasm32-unknown-unknown/release/*.wasm ${db_container}:/


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix an docker container name issue in `local-dev.sh` script.

## What is the current behavior?

Currently the db container name is hard coded, which is an issue if use choose local project names other than `supabase`.

## What is the new behavior?

Get the db container name dynamically, instead of hard coding.

## Additional context

N/A
