### PR TITLE
ci: add cargo component version in CI

### DIFF
--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -29,7 +29,7 @@ jobs:
           rustup target add wasm32-unknown-unknown
 
           # install Wasm component
-          cargo install cargo-component --locked
+          cargo install cargo-component --locked --version 0.13.2
 
       - name: Build Wasm FDW
         run: |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This project is a normal Rust library project, so we will assume you have instal
 2. Install the [WebAssembly Component Model subcommand](https://github.com/bytecodealliance/cargo-component):
 
    ```bash
-   cargo install cargo-component --version 0.13.2
+   cargo install cargo-component --locked --version 0.13.2
    ```
 
 ### Implement the foreign data wrapper logic


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to add version number to `cargo-component` installation in CI, so it won't break if any new version released upstream.

## What is the current behavior?

N/A

## What is the new behavior?

N/A

## Additional context

README is also updated to be in sync with CI.
