### PR TITLE
fix: fix rust version to 1.81.0 in github workflow

### DIFF
--- a/.github/workflows/release_wasm_fdw.yml
+++ b/.github/workflows/release_wasm_fdw.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Rust
         run: |
           # install Rust
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain stable && \
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal --default-toolchain 1.81.0 && \
             rustup --version && \
             rustc --version && \
             cargo --version
@@ -29,7 +29,13 @@ jobs:
           rustup target add wasm32-unknown-unknown
 
           # install Wasm component
-          cargo install cargo-component --locked --version 0.13.2
+          cargo install cargo-component --version 0.13.2
+
+          # install rustfmt for the toolchain
+          rustup component add rustfmt
+
+          # show all installed packagies
+          cargo install --list
 
       - name: Build Wasm FDW
         run: |


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR is to fix Rust version 1.81.0 in github workflow.

## What is the current behavior?

The Rust is on stable channel so its version is always latest, which may cause the compiled wasm file not compatible with old version of wasm runtime.

## What is the new behavior?

Fix Rust version to 1.81.0 in release workflow.

## Additional context

N/A
